### PR TITLE
MON-3323 Create session provider

### DIFF
--- a/SDK/src/sdk/lib/CheckoutComponent.ts
+++ b/SDK/src/sdk/lib/CheckoutComponent.ts
@@ -16,6 +16,7 @@ import { buildFrameUrl, createSandboxedIframe } from '../core/iframe/createIfram
 import { resolveForm } from '../core/form/resolveForm';
 
 import { Logger, makeLogger, type LogLevel } from '../core/utils/Logger';
+import type { SessionProvider } from './initialize';
 
 type PublicKey = string;
 type CSSVars = Record<string, string>;
@@ -172,7 +173,8 @@ export class CheckoutComponent implements CheckoutPort {
     this.containerEl = mountRoot;
     mountRoot.innerHTML = '';
 
-    this.sessionId = await createSession(this.publicKey);
+    const provider = this.options.getSessionId as SessionProvider | undefined;
+    this.sessionId = provider ? await provider() : await createSession(this.publicKey);
 
     const iframeSrc = buildFrameUrl(this.frameUrl, {
       parentOrigin: this.parentOrigin,

--- a/SDK/src/sdk/lib/ExpressComponent.ts
+++ b/SDK/src/sdk/lib/ExpressComponent.ts
@@ -63,7 +63,9 @@ export class ExpressComponent
 
         mountRoot.innerHTML = '';
 
-        const sessionId = await createSession(this.publicKey);
+        const provider = this.options.getSessionId as ((...args: unknown[]) => Promise<string>) | undefined;
+        const sessionId = provider ? await provider() : await createSession(this.publicKey);
+
         this.debug('created session', { hasSessionId: Boolean(sessionId) });
 
         const iframeSrc = buildFrameUrl(this.frameUrl, {

--- a/SDK/src/sdk/lib/initialize.ts
+++ b/SDK/src/sdk/lib/initialize.ts
@@ -1,10 +1,12 @@
 import { CheckoutComponent } from './CheckoutComponent';
 import { ExpressComponent } from './ExpressComponent';
 import { fetchAccessKeyDetails, type AccessKeyDetails } from '../core/init/fetchAccessKey';
+import { createSession } from '../core/init/createSession';
 
 type PublicKey = string;
 
 export type ComponentType = 'checkout' | 'express';
+export type SessionProvider = () => Promise<string>;
 
 export interface InitOptions {
   [key: string]: unknown;
@@ -12,6 +14,7 @@ export interface InitOptions {
 
 export interface ComponentOptions extends InitOptions {
   applePayEnabled?: boolean;
+  getSessionId?: SessionProvider;
 }
 
 function validatePublicKey(key: PublicKey): void {
@@ -20,11 +23,13 @@ function validatePublicKey(key: PublicKey): void {
 
 function buildComponentOptions(
   base: InitOptions,
-  access: AccessKeyDetails
+  access: AccessKeyDetails,
+  getSessionId: SessionProvider
 ): ComponentOptions {
   return {
     ...base,
-    applePayEnabled: access.applePayEnabled, 
+    applePayEnabled: access.applePayEnabled,
+    getSessionId,
   };
 }
 
@@ -43,20 +48,43 @@ function createByType(
   }
 }
 
+function createSessionManager(publicKey: PublicKey) {
+  let pending: Promise<string> | null = null;
+
+  const getSessionId: SessionProvider = () => {
+    if (!pending) {
+      // cache the PROMISE so concurrent checkout+express mounts share one POST /session
+      pending = createSession(publicKey).catch((err) => {
+        pending = null;
+        throw err;
+      });
+    }
+    return pending;
+  };
+
+  const resetSession = () => { 
+    pending = null; 
+  };
+
+  return { getSessionId, resetSession };
+}
+
 export async function init(publicKey: PublicKey, options: InitOptions = {}) {
   validatePublicKey(publicKey);
 
   const defaultOptions: InitOptions = { ...options };
-
   const accessKeyDetails = await fetchAccessKeyDetails(publicKey);
+  const session = createSessionManager(publicKey);
 
   return {
     createComponent(
       type: ComponentType,
       componentOptions: InitOptions = defaultOptions
     ) {
-      const mergedOptions = buildComponentOptions(componentOptions, accessKeyDetails);
+      const mergedOptions = buildComponentOptions(componentOptions, accessKeyDetails, session.getSessionId);
       return createByType(type, publicKey, mergedOptions);
     },
+    getSessionId: session.getSessionId,
+    resetSession: session.resetSession, // call on session-expired to force a fresh one
   };
 }


### PR DESCRIPTION
Added a session management provider, allowing both the `CheckoutComponent` and `ExpressComponent` to share a single session and enabling session reuse and reset (optional). 