### PR TITLE
SAM-7566 Checking parent origin before accepting origin ref from ping

### DIFF
--- a/SDK/src/expressCheckout/components/ExpressCheckoutApp.tsx
+++ b/SDK/src/expressCheckout/components/ExpressCheckoutApp.tsx
@@ -90,6 +90,10 @@ const ExpressCheckoutApp: React.FC = () => {
             });
 
             if (event?.data?.type === "PING_FROM_PARENT") {
+                if (event.origin !== getParentOriginParam()) {
+                    return; // don't trust an unexpected origin
+                }
+
                 allowedOriginRef.current = event.origin;
                 iframeLogger.info("handshake: parent origin captured", { origin: event.origin });
 

--- a/SDK/src/hostedFields/components/HostedFieldsApp.tsx
+++ b/SDK/src/hostedFields/components/HostedFieldsApp.tsx
@@ -194,6 +194,10 @@ const HostedFieldsApp: React.FC = () => {
             iframeLogger.debug('message: received', { origin: event.origin, type: event?.data?.type });
 
             if (event?.data?.type === 'PING_FROM_PARENT') {
+                if (event.origin !== getParentOriginParam()) {
+                    return; // don't trust an unexpected origin
+                }
+
                 allowedOriginRef.current = event.origin;
                 iframeLogger.info('handshake: parent origin captured', { origin: event.origin });
 


### PR DESCRIPTION
Added check as requested.

I’d like to repeat my comment from MON-3243.

> Note regarding 2 (H2):
> 
> The component gets the origin ref in another parameter, but PING_FROM_PARENT can overwrite it. I can’t help but think this is done for some undocumented reason and something will break if it’s not done.